### PR TITLE
Detekter tegnsett

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <session.cookie.secure>true</session.cookie.secure>
         <logstash-logback-encoder.version>6.2</logstash-logback-encoder.version>
+        <juniversalchardet.version>2.3.0</juniversalchardet.version>
     </properties>
 
     <profiles>
@@ -269,6 +270,11 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.albfernandez</groupId>
+            <artifactId>juniversalchardet</artifactId>
+            <version>${juniversalchardet.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/no/nav/xmlstilling/ws/web/transport/http/SoapServlet.java
+++ b/src/main/java/no/nav/xmlstilling/ws/web/transport/http/SoapServlet.java
@@ -81,7 +81,7 @@ public abstract class SoapServlet extends HttpServlet {
         out.close();
     }
 
-    protected String detekterTegnsett(byte[] tegn) {
+    String detekterTegnsett(byte[] tegn) {
         String detectedCharset = null;
         String defaultCharset = "UTF-8";
         if (tegn != null && tegn.length > 0) {

--- a/src/test/java/no/nav/xmlstilling/ws/web/transport/http/SoapServletTegnsettTest.java
+++ b/src/test/java/no/nav/xmlstilling/ws/web/transport/http/SoapServletTegnsettTest.java
@@ -1,0 +1,38 @@
+package no.nav.xmlstilling.ws.web.transport.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SoapServletTegnsettTest {
+    @Test
+    public void skalTolkeISO88591() throws Exception {
+        SoapServlet ss = createServlet();
+        String detektertTegnsett =
+                ss.detekterTegnsett("Dette hærre e en tekst med ISO-8859-1".getBytes("ISO-8859-1"));
+        Assert.assertEquals("ISO-8859-1", detektertTegnsett);
+    }
+    @Test
+    public void skalTolkeUTF8() throws Exception {
+        SoapServlet ss = createServlet();
+        String detektertTegnsett =
+                ss.detekterTegnsett("Dette hærre e en tekst med UTF-8".getBytes("UTF-8"));
+        Assert.assertEquals("UTF-8", detektertTegnsett);
+    }
+    @Test
+    public void skalTolkeUTF8SomDefault() throws Exception {
+        SoapServlet ss = createServlet();
+        String detektertTegnsett =
+                ss.detekterTegnsett("Dette herre e en ANSI-tekst".getBytes("UTF-8"));
+        Assert.assertEquals("UTF-8", detektertTegnsett);
+    }
+
+
+    private SoapServlet createServlet() {
+        return new SoapServlet() {
+            @Override
+            protected SoapServletResponse getResponseMessage(boolean xmlIsWellFormed) {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Bruker juniversalchardet for å detektere og logge tegnsett brukt i SOAP-requester.
Foreløpig kun logging.